### PR TITLE
Add Magic Monkei instructions to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ Path: opennx/opennx.github.io/main/tinfoil.json
 Title: Open NX
 ```
 
+### Magic Monkei
+
+VIP Tinfoil Shop. [Subscribe](https://app.magicmonkei.com/signup?r=opennx) to Magic Monkei and access a vast library of Tinfoil games. 
+Next, add your user tinfoil server:
+
+```
+Protocol: https
+Host: magicmonkei.com
+Path: /tinfoil
+Username: your-username 
+Password: your-password
+Title: Magic Monkei
+```
+
+Or go to this host and install the Magic Monkei app:
+
+```
+Protocol: https
+Host: magicmonkei.com/app
+Title: Magic Monkei App
+```
+
 ## Ghost eShop 
 ```
 Protocol: https
@@ -79,27 +101,6 @@ Host: cyrilz87.net
 Title: Egg Fried Rice Shop
 ```
 
-## Magic Monkei
-
-VIP Tinfoil Shop. [Subscribe](https://app.magicmonkei.com/signup?r=opennx) to Magic Monkei and access a vast library of Tinfoil games. 
-Next, add your user tinfoil server:
-
-```
-Protocol: https
-Host: magicmonkei.com
-Path: /tinfoil
-Username: your-username 
-Password: your-password
-Title: Magic Monkei
-```
-
-Or go to this host and install the Magic Monkei app:
-
-```
-Protocol: https
-Host: magicmonkei.com/app
-Title: Magic Monkei App
-```
 ------------
 
 ## Ecchi's Firmware Archives (download all of switch firmware from Tinfoil)


### PR DESCRIPTION
Added instructions for using the Magic Monkei service, including server details and app installation on the top of the page.